### PR TITLE
0.4.x develop issue 42 package info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 *.log
 diag-*.png
 .asciidoctor/
-
+package-info.java

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,22 @@
                     </additionalparam>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>exec-maven-plugin</artifactId>
+                <groupId>org.codehaus.mojo</groupId>
+                <executions>
+                    <execution><!-- Run our version calculation script -->
+                        <id>package-info.java generation</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>${basedir}/scripts/package-info-adoc_to_package-info-java.sh</executable>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.dakusui</groupId>
     <artifactId>scriptiveunit</artifactId>
@@ -121,7 +122,7 @@
                         <format>html</format>
                         <format>xml</format>
                     </formats>
-                    <check />
+                    <check/>
                 </configuration>
             </plugin>
             <plugin>
@@ -179,7 +180,10 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <executable>${basedir}/scripts/package-info-adoc_to_package-info-java.sh</executable>
+                            <executable>bash</executable>
+                            <arguments>
+                                <argument>${basedir}/scripts/package-info-adoc_to_package-info-java.sh</argument>
+                            </arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/scripts/package-info-adoc_to_package-info-java.sh
+++ b/scripts/package-info-adoc_to_package-info-java.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash -eux
+
+function convert_package_info_adoc_to_package_info_java() {
+  local _base_dir=$1
+  local _rel_dir=$2
+  local _i
+  local _out="${_base_dir}/${_rel_dir}/package-info.java"
+  rm -f ${_out}
+  touch ${_out}
+  echo "/**" >> ${_out}
+  while IFS= read -r _i
+  do
+    echo " * ${_i}" >> ${_out}
+  done < "${_base_dir}/${_rel_dir}/package-info.adoc"
+
+  echo " */" >> ${_out}
+  echo "package ${_rel_dir//\//.};" >> ${_out}
+}
+
+# find src/main/java -name 'package-info.adoc' -exec echo convert_package_info_adoc_to_package_info_java src/main/java
+# convert_package_info_adoc_to_package_info_java /Users/hiroshi.ukai/Documents/scriptiveunit/src/main/java com/github/dakusui/scriptiveunit/utils
+
+base=src/main/java
+for i in $(find ${base} -name 'package-info.adoc'); do
+  convert_package_info_adoc_to_package_info_java ${base} $(dirname ${i#${base}/})
+done;

--- a/src/main/java/com/github/dakusui/scriptiveunit/package-info.java
+++ b/src/main/java/com/github/dakusui/scriptiveunit/package-info.java
@@ -1,1 +1,0 @@
-package com.github.dakusui.scriptiveunit;

--- a/src/main/java/com/github/dakusui/scriptiveunit/package-info.java
+++ b/src/main/java/com/github/dakusui/scriptiveunit/package-info.java
@@ -1,6 +1,1 @@
-/**
- * Hello, world.
- *
- * This is {@code ScriptiveUnit} package.
- */
 package com.github.dakusui.scriptiveunit;

--- a/src/main/java/com/github/dakusui/scriptiveunit/utils/package-info.adoc
+++ b/src/main/java/com/github/dakusui/scriptiveunit/utils/package-info.adoc
@@ -1,0 +1,3 @@
+Hello, world.
+
+This is {@code ScriptiveUnit} package.


### PR DESCRIPTION
Issue #42 : Implement a mechanism where ```package-info.java``` is generated from ```package-info.adoc``` automatically on ```javadoc:javadoc```.
